### PR TITLE
LZO1X999 initialization refactoring

### DIFF
--- a/lzo-core/src/main/java/org/anarres/lzo/LzoAlgorithm.java
+++ b/lzo-core/src/main/java/org/anarres/lzo/LzoAlgorithm.java
@@ -53,7 +53,6 @@ public enum LzoAlgorithm {
     LZO1C,
     LZO1F,
     LZO1X,
-    LZO1X_999,
     LZO1Y,
     LZO1Z,
     LZO2A;

--- a/lzo-core/src/main/java/org/anarres/lzo/LzoCompressor1x_999.java
+++ b/lzo-core/src/main/java/org/anarres/lzo/LzoCompressor1x_999.java
@@ -47,7 +47,7 @@ public class LzoCompressor1x_999 extends AbstractLzo1Compressor {
     private int compression_level;
 
     public LzoCompressor1x_999(int level) {
-        super(LzoAlgorithm.LZO1X_999);
+        super(LzoAlgorithm.LZO1X, LzoConstraint.COMPRESSION);
         if (level > 0 && level < 10)
             compression_level = level - 1;
         else
@@ -580,7 +580,7 @@ public class LzoCompressor1x_999 extends AbstractLzo1Compressor {
 
     @Override 
     public String toString() {
-        return "LZO1X999" + getCompressionLevel();
+        return "LZO1X999-" + getCompressionLevel();
     }
 
     public int compress(byte[] in, int in_base, int in_len,

--- a/lzo-core/src/main/java/org/anarres/lzo/LzoLibrary.java
+++ b/lzo-core/src/main/java/org/anarres/lzo/LzoLibrary.java
@@ -61,21 +61,34 @@ public class LzoLibrary {
     }
 
     /**
-     * Returns a new compressor for the given algorithm. Default compression level for LZO1X999 is 7.
+     * Returns a new compressor for the given algorithm. 
+     *
+     * Currently the only available constraint is {@link LzoConstraint#COMPRESSION}. 
+     * Applied to {@link LzoAlgorithm#LZO1X} algorithm, it yields an LZO1X999 compressor with a compression level of 7.
      */
     @Nonnull
     public LzoCompressor newCompressor(@CheckForNull LzoAlgorithm algorithm, @CheckForNull LzoConstraint constraint) {
         if (algorithm == null)
             return new LzoCompressor1x_1();
         switch (algorithm) {
+
             case LZO1X:
-                return new LzoCompressor1x_1();
-            case LZO1X_999:
-                return new LzoCompressor1x_999(7);
+                if (constraint == null)
+                   return new LzoCompressor1x_1();                
+                else if (constraint == LzoConstraint.COMPRESSION)
+                   return new LzoCompressor1x_999(7);
+                else 
+                   throw new UnsupportedOperationException("Unsupported combination " + algorithm + "/" + constraint);
+
             case LZO1Y:
-                return new LzoCompressor1y_1();
+                if (constraint == null)
+                   return new LzoCompressor1y_1();
+                else 
+                   throw new UnsupportedOperationException("Unsupported combination " + algorithm + "/" + constraint);
+
             default:
                 throw new UnsupportedOperationException("Unsupported algorithm " + algorithm);
+
         }
     }
 
@@ -90,7 +103,6 @@ public class LzoLibrary {
         switch (algorithm) {
 
             case LZO1X:
-            case LZO1X_999:
                 if (constraint == LzoConstraint.SAFETY)
                     return new LzoDecompressor1x_safe();
                 else

--- a/lzo-core/src/main/java/org/anarres/lzo/LzopOutputStream.java
+++ b/lzo-core/src/main/java/org/anarres/lzo/LzopOutputStream.java
@@ -45,6 +45,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.zip.Adler32;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;

--- a/lzo-core/src/main/java/org/anarres/lzo/LzopOutputStream.java
+++ b/lzo-core/src/main/java/org/anarres/lzo/LzopOutputStream.java
@@ -52,11 +52,11 @@ import javax.annotation.CheckForNull;
 import javax.annotation.CheckForSigned;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- *
  * @author shevek
  */
 public class LzopOutputStream extends LzoOutputStream {
@@ -71,7 +71,7 @@ public class LzopOutputStream extends LzoOutputStream {
 
     /**
      * Constructs a new LzopOutputStream.
-     *
+     * <p/>
      * I recommend limiting flags to the following unless you REALLY know what
      * you are doing:
      * <ul>
@@ -111,9 +111,17 @@ public class LzopOutputStream extends LzoOutputStream {
             dob.writeShort(LzopConstants.LZOP_COMPAT_VERSION);
             switch (getAlgorithm()) {
                 case LZO1X:
-                    // case LZO1X_1:
-                    dob.writeByte(LzopConstants.M_LZO1X_1);
-                    dob.writeByte(5);
+                    LzoConstraint[] constraints = getConstraints();
+
+                    if (constraints.length == 0) {
+                        dob.writeByte(LzopConstants.M_LZO1X_1);
+                        dob.writeByte(5);
+                    } else if (constraints.length == 1 && constraints[0] == LzoConstraint.COMPRESSION) {
+                        dob.writeByte(LzopConstants.M_LZO1X_999);
+                        dob.writeByte(getCompressor().getCompressionLevel());
+                    } else
+                        throw new IOException("Unsupported constraint combination for LZO1X: " + Arrays.toString(constraints));
+
                     break;
                 /*
                  case LZO1X_15:
@@ -121,10 +129,6 @@ public class LzopOutputStream extends LzoOutputStream {
                  dob.writeByte(1);
                  break;
                  */
-                case LZO1X_999:
-                    dob.writeByte(LzopConstants.M_LZO1X_999);
-                    dob.writeByte(getCompressor().getCompressionLevel());
-                    break;
                 default:
                     throw new IOException("Incompatible lzop algorithm " + getAlgorithm());
             }

--- a/lzo-core/src/test/java/org/anarres/lzo/LzoAlgorithmTest.java
+++ b/lzo-core/src/test/java/org/anarres/lzo/LzoAlgorithmTest.java
@@ -8,23 +8,24 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.Random;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
- *
  * @author shevek
  */
 public class LzoAlgorithmTest {
 
     private static final Log LOG = LogFactory.getLog(LzoAlgorithmTest.class);
 
-    public void testAlgorithm(LzoAlgorithm algorithm, byte[] orig, String desc) {
-        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, null);
-        LOG.info("\nCompressing " + orig.length + " " + desc + " bytes using " + algorithm);
+    public void testAlgorithm(LzoAlgorithm algorithm, LzoConstraint constraint, byte[] orig, String desc) {
+        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, constraint);
+        LOG.info("\nCompressing " + orig.length + " " + desc + " bytes using " + algorithm + "/" + constraint);
 
         // LOG.info("Original:   " + Arrays.toString(orig));
         byte[] compressed = new byte[orig.length * 2];
@@ -47,16 +48,20 @@ public class LzoAlgorithmTest {
         assertArrayEquals(orig, uncompressed);
     }
 
+    LzoConstraint[] supportedConstraints = { null, LzoConstraint.COMPRESSION };     
+
     // Totally RLE.
     @Test
     public void testBlank() throws Exception {
         byte[] orig = new byte[512 * 1024];
         Arrays.fill(orig, (byte) 0);
         for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-            try {
-                testAlgorithm(algorithm, orig, "blank");
-            } catch (UnsupportedOperationException e) {
-                // LOG.info("Unsupported algorithm " + algorithm);
+            for (LzoConstraint constraint : supportedConstraints) {
+                try {
+                    testAlgorithm(algorithm, constraint, orig, "blank");
+                } catch (UnsupportedOperationException e) {
+                    // LOG.info("Unsupported algorithm " + algorithm);
+                }
             }
         }
     }
@@ -68,10 +73,12 @@ public class LzoAlgorithmTest {
         for (int i = 0; i < orig.length; i++)
             orig[i] = (byte) (i & 0xf);
         for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-            try {
-                testAlgorithm(algorithm, orig, "sequential");
-            } catch (UnsupportedOperationException e) {
-                // LOG.info("Unsupported algorithm " + algorithm);
+            for (LzoConstraint constraint : supportedConstraints) {
+                try {
+                    testAlgorithm(algorithm, constraint, orig, "sequential");
+                } catch (UnsupportedOperationException e) {
+                    // LOG.info("Unsupported algorithm " + algorithm);
+                }
             }
         }
     }
@@ -84,10 +91,12 @@ public class LzoAlgorithmTest {
             byte[] orig = new byte[256 * 1024];
             r.nextBytes(orig);
             for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-                try {
-                    testAlgorithm(algorithm, orig, "random");
-                } catch (UnsupportedOperationException e) {
-                    // LOG.info("Unsupported algorithm " + algorithm);
+                for (LzoConstraint constraint : supportedConstraints) {
+                    try {
+                        testAlgorithm(algorithm, constraint, orig, "random");
+                    } catch (UnsupportedOperationException e) {
+                        // LOG.info("Unsupported algorithm " + algorithm);
+                    }
                 }
             }
         }
@@ -100,10 +109,12 @@ public class LzoAlgorithmTest {
         InputStream in = getClass().getClassLoader().getResourceAsStream(name);
         byte[] orig = IOUtils.toByteArray(in);
         for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-            try {
-                testAlgorithm(algorithm, orig, "class-file");
-            } catch (UnsupportedOperationException e) {
-                // LOG.info("Unsupported algorithm " + algorithm);
+            for (LzoConstraint constraint : supportedConstraints) {
+                try {
+                    testAlgorithm(algorithm, constraint, orig, "class-file");
+                } catch (UnsupportedOperationException e) {
+                    // LOG.info("Unsupported algorithm " + algorithm);
+                }
             }
         }
     }

--- a/lzo-core/src/test/java/org/anarres/lzo/LzoStreamTest.java
+++ b/lzo-core/src/test/java/org/anarres/lzo/LzoStreamTest.java
@@ -12,23 +12,24 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.Random;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
- *
  * @author shevek
  */
 public class LzoStreamTest {
 
     private static final Log LOG = LogFactory.getLog(LzoStreamTest.class);
 
-    public void testAlgorithm(LzoAlgorithm algorithm, byte[] orig) throws IOException {
-        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, null);
-        LOG.info("\nCompressing " + orig.length + " bytes using " + algorithm);
+    public void testAlgorithm(LzoAlgorithm algorithm, LzoConstraint constraint, byte[] orig) throws IOException {
+        LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, constraint);
+        LOG.info("\nCompressing " + orig.length + " bytes using " + algorithm + "/" + constraint);
 
         // LOG.info("Original:   " + Arrays.toString(orig));
         ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -51,6 +52,8 @@ public class LzoStreamTest {
 
         assertArrayEquals(orig, uncompressed);
     }
+
+    LzoConstraint[] supportedConstraints = { null, LzoConstraint.COMPRESSION };     
 
     @Test
     public void testHoldover() throws IOException {
@@ -95,10 +98,12 @@ public class LzoStreamTest {
         byte[] orig = new byte[512 * 1024];
         Arrays.fill(orig, (byte) 0);
         for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-            try {
-                testAlgorithm(algorithm, orig);
-            } catch (UnsupportedOperationException e) {
-                // LOG.info("Unsupported algorithm " + algorithm);
+            for (LzoConstraint constraint : supportedConstraints) {
+                 try {
+                    testAlgorithm(algorithm, constraint, orig);
+                } catch (UnsupportedOperationException e) {
+                    // LOG.info("Unsupported algorithm " + algorithm);
+                }
             }
         }
     }
@@ -110,10 +115,12 @@ public class LzoStreamTest {
         for (int i = 0; i < orig.length; i++)
             orig[i] = (byte) (i & 0xf);
         for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-            try {
-                testAlgorithm(algorithm, orig);
-            } catch (UnsupportedOperationException e) {
-                // LOG.info("Unsupported algorithm " + algorithm);
+            for (LzoConstraint constraint : supportedConstraints) {
+                 try {
+                    testAlgorithm(algorithm, constraint, orig);
+                } catch (UnsupportedOperationException e) {
+                    // LOG.info("Unsupported algorithm " + algorithm);
+                }
             }
         }
     }
@@ -126,10 +133,12 @@ public class LzoStreamTest {
             byte[] orig = new byte[256 * 1024];
             r.nextBytes(orig);
             for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-                try {
-                    testAlgorithm(algorithm, orig);
-                } catch (UnsupportedOperationException e) {
-                    // LOG.info("Unsupported algorithm " + algorithm);
+                for (LzoConstraint constraint : supportedConstraints) {
+                    try {
+                        testAlgorithm(algorithm, constraint, orig);
+                    } catch (UnsupportedOperationException e) {
+                        // LOG.info("Unsupported algorithm " + algorithm);
+                    }
                 }
             }
         }
@@ -142,10 +151,12 @@ public class LzoStreamTest {
         InputStream in = getClass().getClassLoader().getResourceAsStream(name);
         byte[] orig = IOUtils.toByteArray(in);
         for (LzoAlgorithm algorithm : LzoAlgorithm.values()) {
-            try {
-                testAlgorithm(algorithm, orig);
-            } catch (UnsupportedOperationException e) {
-                // LOG.info("Unsupported algorithm " + algorithm);
+            for (LzoConstraint constraint : supportedConstraints) {
+                try {
+                    testAlgorithm(algorithm, constraint, orig);
+                } catch (UnsupportedOperationException e) {
+                    // LOG.info("Unsupported algorithm " + algorithm);
+                }
             }
         }
     }

--- a/lzo-core/src/test/java/org/anarres/lzo/LzopStreamTest.java
+++ b/lzo-core/src/test/java/org/anarres/lzo/LzopStreamTest.java
@@ -50,42 +50,42 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.Random;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
- *
  * @author shevek
  */
 public class LzopStreamTest {
 
     private static final Log LOG = LogFactory.getLog(LzopStreamTest.class);
     private static final long[] FLAGS = new long[]{
-        0L,
-        // Adler32
-        LzopConstants.F_ADLER32_C,
-        LzopConstants.F_ADLER32_D,
-        LzopConstants.F_ADLER32_C | LzopConstants.F_ADLER32_D,
-        // CRC32
-        LzopConstants.F_CRC32_C,
-        LzopConstants.F_CRC32_D,
-        LzopConstants.F_CRC32_C | LzopConstants.F_CRC32_D,
-        // Both
-        LzopConstants.F_ADLER32_C | LzopConstants.F_CRC32_C,
-        LzopConstants.F_ADLER32_D | LzopConstants.F_CRC32_D,
-        LzopConstants.F_ADLER32_C | LzopConstants.F_ADLER32_D | LzopConstants.F_CRC32_C | LzopConstants.F_CRC32_D
+            0L,
+            // Adler32
+            LzopConstants.F_ADLER32_C,
+            LzopConstants.F_ADLER32_D,
+            LzopConstants.F_ADLER32_C | LzopConstants.F_ADLER32_D,
+            // CRC32
+            LzopConstants.F_CRC32_C,
+            LzopConstants.F_CRC32_D,
+            LzopConstants.F_CRC32_C | LzopConstants.F_CRC32_D,
+            // Both
+            LzopConstants.F_ADLER32_C | LzopConstants.F_CRC32_C,
+            LzopConstants.F_ADLER32_D | LzopConstants.F_CRC32_D,
+            LzopConstants.F_ADLER32_C | LzopConstants.F_ADLER32_D | LzopConstants.F_CRC32_C | LzopConstants.F_CRC32_D
     };
-    private static final LzoAlgorithm[] lzopAlgorithms = {LzoAlgorithm.LZO1X, LzoAlgorithm.LZO1X_999};
 
-    public void testAlgorithm(LzoAlgorithm algorithm, byte[] orig) throws IOException {
+    public void testAlgorithm(LzoAlgorithm algorithm, LzoConstraint constraint, byte[] orig) throws IOException {
         for (long flags : FLAGS) {
             try {
-                LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, null);
-                LOG.info("Compressing " + orig.length + " bytes using " + algorithm);
+                LzoCompressor compressor = LzoLibrary.getInstance().newCompressor(algorithm, constraint);
+                LOG.info("Compressing " + orig.length + " bytes using " + algorithm + "/" + constraint);
 
                 // LOG.info("Original:   " + Arrays.toString(orig));
                 ByteArrayOutputStream os = new ByteArrayOutputStream();
@@ -114,14 +114,16 @@ public class LzopStreamTest {
         }
     }
 
+    LzoConstraint[] supportedConstraints = { null, LzoConstraint.COMPRESSION };     
+
     // Totally RLE.
     @Test
     public void testBlank() throws Exception {
         byte[] orig = new byte[512 * 1024];
         Arrays.fill(orig, (byte) 0);
-        for (LzoAlgorithm algorithm : lzopAlgorithms) {
+        for (LzoConstraint constraint : supportedConstraints) {
             try {
-                testAlgorithm(algorithm, orig);
+                testAlgorithm(LzoAlgorithm.LZO1X, constraint, orig);
             } catch (UnsupportedOperationException e) {
                 // LOG.info("Unsupported algorithm " + algorithm);
             }
@@ -134,9 +136,9 @@ public class LzopStreamTest {
         byte[] orig = new byte[512 * 1024];
         for (int i = 0; i < orig.length; i++)
             orig[i] = (byte) (i & 0xf);
-        for (LzoAlgorithm algorithm : lzopAlgorithms) {
+        for (LzoConstraint constraint : supportedConstraints) {
             try {
-                testAlgorithm(algorithm, orig);
+                testAlgorithm(LzoAlgorithm.LZO1X, constraint, orig);
             } catch (UnsupportedOperationException e) {
                 // LOG.info("Unsupported algorithm " + algorithm);
             }
@@ -150,9 +152,9 @@ public class LzopStreamTest {
         for (int i = 0; i < 10; i++) {
             byte[] orig = new byte[256 * 1024];
             r.nextBytes(orig);
-            for (LzoAlgorithm algorithm : lzopAlgorithms) {
+            for (LzoConstraint constraint : supportedConstraints) {
                 try {
-                    testAlgorithm(algorithm, orig);
+                    testAlgorithm(LzoAlgorithm.LZO1X, constraint, orig);
                 } catch (UnsupportedOperationException e) {
                     // LOG.info("Unsupported algorithm " + algorithm);
                 }
@@ -166,9 +168,9 @@ public class LzopStreamTest {
         LOG.info("Class is " + name);
         InputStream in = getClass().getClassLoader().getResourceAsStream(name);
         byte[] orig = IOUtils.toByteArray(in);
-        for (LzoAlgorithm algorithm : lzopAlgorithms) {
+        for (LzoConstraint constraint : supportedConstraints) {
             try {
-                testAlgorithm(algorithm, orig);
+                testAlgorithm(LzoAlgorithm.LZO1X, constraint, orig);
             } catch (UnsupportedOperationException e) {
                 // LOG.info("Unsupported algorithm " + algorithm);
             }


### PR DESCRIPTION
I'd like to be able to use LZO1X999 from Hadoop, but it looks like `lzo-hadoop` is using the constraint system to initialize the compressor. So I refactored the way LZO1X999 is initialized.

It feels slightly weird to use `null` in the compressor selection logic, but I guess it works.