### PR TITLE
LzoInputStream read method bug

### DIFF
--- a/lzo-core/src/main/java/org/anarres/lzo/LzoInputStream.java
+++ b/lzo-core/src/main/java/org/anarres/lzo/LzoInputStream.java
@@ -89,7 +89,7 @@ public class LzoInputStream extends InputStream {
     public int read() throws IOException {
         if (!fill())
             return -1;
-        return outputBuffer[outputBufferPos++];
+        return outputBuffer[outputBufferPos++] & 0xFF;
     }
 
     @Override


### PR DESCRIPTION
In the read method returned value is the 'int', but the source value is the 'byte'. So, we have 'byte' to 'int' conversion here and for the byte values greater 0x80 we will have negative 'int' values. Negative return value in the read method means EOF. This is the BUG.