### PR TITLE
embrace Apache Commons Compress' ServiceLoader support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ project(':lzo-core') {
 project(':lzo-commons') {
 	dependencies {
 		compile project(':lzo-core')
-		compile 'org.apache.commons:commons-compress:1.9'
+		compile 'org.apache.commons:commons-compress:1.13'
 
 		testCompile project(':lzo-core').sourceSets.test.output
 	}

--- a/lzo-commons/src/main/java/org/anarres/lzo/commons/LzoCompressorStreamProvider.java
+++ b/lzo-commons/src/main/java/org/anarres/lzo/commons/LzoCompressorStreamProvider.java
@@ -1,0 +1,52 @@
+package org.anarres.lzo.commons;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.anarres.lzo.LzoAlgorithm;
+import org.apache.commons.compress.compressors.CompressorInputStream;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
+import org.apache.commons.compress.compressors.CompressorStreamProvider;
+
+/**
+ * Implements Apache Commons Compress' CompressorStreamProvider
+ * interface to make LZO compression available to its
+ * CompressorStreamFactory via ServiceLoader.
+ */
+public class LzoCompressorStreamProvider implements CompressorStreamProvider {
+    private static final Set<String> COMPRESSION_ALGORITHMS =
+        Collections.unmodifiableSet(new HashSet(Arrays.asList(
+            LzoAlgorithm.LZO1X.name(),
+            LzoAlgorithm.LZO1Y.name())));
+    private static final Set<String> DECOMPRESSION_ALGORITHMS =
+        Collections.unmodifiableSet(new HashSet(Arrays.asList(
+            LzoAlgorithm.LZO1X.name(),
+            LzoAlgorithm.LZO1Y.name(),
+            LzoAlgorithm.LZO1Z.name())));
+
+    @Override
+    public  Set<String> getInputStreamCompressorNames() {
+        return DECOMPRESSION_ALGORITHMS;
+    }
+
+    @Override
+    public  Set<String> getOutputStreamCompressorNames() {
+        return COMPRESSION_ALGORITHMS;
+    }
+
+    @Override
+    public CompressorInputStream createCompressorInputStream(@Nonnull final String name,
+        @Nonnull final InputStream in, final boolean ignoredDecompressUntilEOF) {
+        return new LzoCompressorInputStream(in, LzoAlgorithm.valueOf(name));
+    }
+
+    @Override
+    public CompressorOutputStream createCompressorOutputStream(@Nonnull final String name,
+        @Nonnull final OutputStream out) {
+        return new LzoCompressorOutputStream(out, LzoAlgorithm.valueOf(name));
+    }
+}

--- a/lzo-commons/src/main/resources/META-INF/services/org.apache.commons.compress.compressors.CompressorStreamProvider
+++ b/lzo-commons/src/main/resources/META-INF/services/org.apache.commons.compress.compressors.CompressorStreamProvider
@@ -1,0 +1,1 @@
+org.anarres.lzo.commons.LzoCompressorStreamProvider

--- a/lzo-commons/src/test/java/org/anarres/lzo/commons/LzoCompressorStreamProviderTest.java
+++ b/lzo-commons/src/test/java/org/anarres/lzo/commons/LzoCompressorStreamProviderTest.java
@@ -1,0 +1,54 @@
+package org.anarres.lzo.commons;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorInputStream;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LzoCompressorStreamProviderTest {
+    private void testAlgorithm(String algorithm, byte[] orig)
+        throws IOException, CompressorException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        CompressorOutputStream cs = new CompressorStreamFactory()
+            .createCompressorOutputStream(algorithm, os);
+        assertNotNull("didn't get any output stream for algorithm " + algorithm, cs);
+        assertTrue("stream is not an LzoCompressorOutputStream but " + cs.getClass()
+                   + " for algorithm " + algorithm,
+                   cs instanceof LzoCompressorOutputStream);
+        cs.write(orig);
+        cs.close();
+
+        ByteArrayInputStream is = new ByteArrayInputStream(os.toByteArray());
+        CompressorInputStream us = new CompressorStreamFactory()
+            .createCompressorInputStream(algorithm, is);
+        assertNotNull("didn't get any input stream for algorithm " + algorithm, us);
+        assertTrue("stream is not an LzoCompressorInputStream but " + us.getClass()
+                   + " for algorithm " + algorithm,
+                   us instanceof LzoCompressorInputStream);
+        DataInputStream ds = new DataInputStream(us);
+        byte[] uncompressed = new byte[orig.length];
+        ds.readFully(uncompressed);
+
+        assertArrayEquals(orig, uncompressed);
+    }
+
+    // Highly cyclic.
+    @Test
+    public void testSequence() throws Exception {
+        byte[] orig = new byte[512 * 1024];
+        for (int i = 0; i < orig.length; i++)
+            orig[i] = (byte) (i & 0xf);
+        for (String algorithm : new LzoCompressorStreamProvider()
+                 .getOutputStreamCompressorNames()) {
+            testAlgorithm(algorithm, orig);
+        }
+    }
+
+}


### PR DESCRIPTION
Apache Commons Compress 1.13 has added support for pluggable compressor stream providers using the standard Java `ServiceLoader` mechanism with the latest release.

With this PR `lzo-commons` on the classpath (together with `core`, of course) will be enough to use LZO directly via `CompressorStreamFactory`. If you need more control over the (de)compressor's configuration you'll still have to use the `Lzo*Stream` classes directly, though.