### PR TITLE
fix IndexOutOfBounds

### DIFF
--- a/lzo-core/src/main/java/org/anarres/lzo/LzoOutputStream.java
+++ b/lzo-core/src/main/java/org/anarres/lzo/LzoOutputStream.java
@@ -175,7 +175,7 @@ public class LzoOutputStream extends OutputStream {
             throw new IllegalStateException("Cannot accept input while holdover is present.");
 
         inputHoldoverBuffer = Arrays.copyOfRange(b, off, off + len);
-        inputHoldoverBufferPos = off;
+        inputHoldoverBufferPos = 0;
         inputHoldoverBufferLen = len;
         compact();
 


### PR DESCRIPTION
If somene calls 'write' with non-zero offset he'll get IndexOutOfBoundsException. 
So you should use zero offset here or don't copy input buffer.